### PR TITLE
Add interactive music visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # codex
+
 Testing Codex's abilities
+
+## Interactive Music Visualizer
+
+This repository includes a minimal WebGL-based music visualizer. It captures audio from your microphone and displays a 3D cube that pulses with the sound.
+
+### Running
+
+1. Serve the repository with a local web server (for example `npx serve .`).
+2. Open `index.html` in a modern browser.
+3. Click **Start Visualizer** and allow microphone access.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Interactive Music Visualizer</title>
+    <style>
+        body { margin: 0; overflow: hidden; }
+        #startButton { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); padding: 1rem 2rem; font-size: 1rem; }
+    </style>
+</head>
+<body>
+    <button id="startButton">Start Visualizer</button>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,61 @@
+const startButton = document.getElementById('startButton');
+let audioCtx, analyser, dataArray;
+let scene, camera, renderer, cube;
+
+startButton.addEventListener('click', async () => {
+    startButton.remove();
+    try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        setupAudio(stream);
+        initThree();
+        animate();
+    } catch (err) {
+        console.error('Microphone access rejected:', err);
+    }
+});
+
+function setupAudio(stream) {
+    audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    const source = audioCtx.createMediaStreamSource(stream);
+    analyser = audioCtx.createAnalyser();
+    analyser.fftSize = 256;
+    source.connect(analyser);
+    dataArray = new Uint8Array(analyser.frequencyBinCount);
+}
+
+function initThree() {
+    scene = new THREE.Scene();
+    camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+    renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    document.body.appendChild(renderer.domElement);
+
+    const geometry = new THREE.BoxGeometry();
+    const material = new THREE.MeshStandardMaterial({ color: 0x00ff00 });
+    cube = new THREE.Mesh(geometry, material);
+    scene.add(cube);
+
+    const light = new THREE.PointLight(0xffffff, 1);
+    light.position.set(0, 2, 2);
+    scene.add(light);
+
+    camera.position.z = 5;
+    window.addEventListener('resize', onWindowResize);
+}
+
+function onWindowResize() {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+function animate() {
+    requestAnimationFrame(animate);
+    analyser.getByteFrequencyData(dataArray);
+    const avg = dataArray.reduce((sum, v) => sum + v, 0) / dataArray.length;
+    const scale = 1 + avg / 256;
+    cube.scale.set(scale, scale, scale);
+    cube.rotation.x += 0.01;
+    cube.rotation.y += 0.01;
+    renderer.render(scene, camera);
+}


### PR DESCRIPTION
## Summary
- create a basic WebGL music visualizer using Three.js
- add index.html and script.js
- document how to run the example

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6844cb3ade10832283d9c6d154c29460