### PR TITLE
Add visualization selection and audio file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # codex
+
 Testing Codex's abilities
+
+## Interactive Music Visualizer
+
+This repository includes a simple WebGL-based music visualizer. It can visualize microphone input or a provided `.wav` file using different shapes such as a cube, sphere, particles or bars.
+
+### Running
+
+1. Serve the repository with a local web server (for example `npx serve .`).
+2. Open `index.html` in a modern browser.
+3. Choose a visualization type from the dropdown and select **Microphone** or **WAV File** as the audio source. If using a file, pick a `.wav` file from your computer.
+4. Click **Start Visualizer** and allow microphone access if required.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Interactive Music Visualizer</title>
+    <style>
+        body { margin: 0; overflow: hidden; }
+        #controls { position: absolute; top: 10px; left: 10px; z-index: 10; background: rgba(255,255,255,0.8); padding: 0.5rem; border-radius: 4px; }
+    </style>
+</head>
+<body>
+    <div id="controls">
+        <select id="vizSelect">
+            <option value="cube">Cube</option>
+            <option value="sphere">Sphere</option>
+            <option value="particles">Particles</option>
+            <option value="bars">Bars</option>
+        </select>
+        <label><input type="radio" name="audioSource" value="mic" checked> Microphone</label>
+        <label><input type="radio" name="audioSource" value="file"> WAV File</label>
+        <input id="audioFile" type="file" accept=".wav" style="display:none">
+        <button id="startButton">Start Visualizer</button>
+    </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,134 @@
+const startButton = document.getElementById('startButton');
+const vizSelect = document.getElementById('vizSelect');
+const audioFileInput = document.getElementById('audioFile');
+let audioCtx, analyser, dataArray;
+let scene, camera, renderer, visual;
+
+document.querySelectorAll('input[name="audioSource"]').forEach(radio => {
+    radio.addEventListener('change', () => {
+        if (radio.value === 'file') {
+            audioFileInput.style.display = 'inline';
+        } else {
+            audioFileInput.style.display = 'none';
+        }
+    });
+});
+
+startButton.addEventListener('click', async () => {
+    startButton.disabled = true;
+    try {
+        const sourceType = document.querySelector('input[name="audioSource"]:checked').value;
+        if (sourceType === 'mic') {
+            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            setupMicAudio(stream);
+        } else {
+            const file = audioFileInput.files[0];
+            if (!file) {
+                alert('Select a WAV file first');
+                startButton.disabled = false;
+                return;
+            }
+            await setupFileAudio(file);
+        }
+        initThree(vizSelect.value);
+        animate();
+    } catch (err) {
+        console.error('Audio initialization failed:', err);
+        startButton.disabled = false;
+    }
+});
+
+function setupMicAudio(stream) {
+    audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    const source = audioCtx.createMediaStreamSource(stream);
+    analyser = audioCtx.createAnalyser();
+    analyser.fftSize = 256;
+    source.connect(analyser);
+    dataArray = new Uint8Array(analyser.frequencyBinCount);
+}
+
+async function setupFileAudio(file) {
+    audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    const arrayBuffer = await file.arrayBuffer();
+    const audioBuffer = await audioCtx.decodeAudioData(arrayBuffer);
+    const source = audioCtx.createBufferSource();
+    source.buffer = audioBuffer;
+    source.loop = true;
+    analyser = audioCtx.createAnalyser();
+    analyser.fftSize = 256;
+    source.connect(analyser);
+    analyser.connect(audioCtx.destination);
+    source.start();
+    dataArray = new Uint8Array(analyser.frequencyBinCount);
+}
+
+function initThree(type) {
+    scene = new THREE.Scene();
+    camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+    renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    document.body.appendChild(renderer.domElement);
+
+    switch (type) {
+        case 'sphere':
+            visual = new THREE.Mesh(new THREE.SphereGeometry(), new THREE.MeshStandardMaterial({ color: 0x00ff00 }));
+            break;
+        case 'particles':
+            const pGeom = new THREE.BufferGeometry();
+            const count = 500;
+            const positions = new Float32Array(count * 3);
+            for (let i = 0; i < count * 3; i++) {
+                positions[i] = (Math.random() - 0.5) * 4;
+            }
+            pGeom.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+            const pMat = new THREE.PointsMaterial({ color: 0x00ff00, size: 0.05 });
+            visual = new THREE.Points(pGeom, pMat);
+            break;
+        case 'bars':
+            visual = new THREE.Group();
+            const barCount = 32;
+            for (let i = 0; i < barCount; i++) {
+                const bar = new THREE.Mesh(new THREE.BoxGeometry(0.2, 1, 0.2), new THREE.MeshStandardMaterial({ color: 0x00ff00 }));
+                bar.position.x = (i - barCount / 2) * 0.25;
+                visual.add(bar);
+            }
+            break;
+        case 'cube':
+        default:
+            visual = new THREE.Mesh(new THREE.BoxGeometry(), new THREE.MeshStandardMaterial({ color: 0x00ff00 }));
+    }
+    scene.add(visual);
+
+    const light = new THREE.PointLight(0xffffff, 1);
+    light.position.set(0, 2, 2);
+    scene.add(light);
+
+    camera.position.z = 5;
+    window.addEventListener('resize', onWindowResize);
+}
+
+function onWindowResize() {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+function animate() {
+    requestAnimationFrame(animate);
+    analyser.getByteFrequencyData(dataArray);
+    const avg = dataArray.reduce((sum, v) => sum + v, 0) / dataArray.length;
+    const scale = 1 + avg / 256;
+    if (vizSelect.value === 'bars' && visual instanceof THREE.Group) {
+        const bars = visual.children;
+        const step = Math.floor(dataArray.length / bars.length);
+        bars.forEach((bar, i) => {
+            const val = dataArray[i * step] / 255;
+            bar.scale.y = 0.1 + val * 2;
+        });
+    } else {
+        visual.scale.set(scale, scale, scale);
+        visual.rotation.x += 0.01;
+        visual.rotation.y += 0.01;
+    }
+    renderer.render(scene, camera);
+}


### PR DESCRIPTION
## Summary
- add dropdown and audio source controls to `index.html`
- extend script to handle microphone or WAV file input
- support multiple visualization types (cube, sphere, particles, bars)
- document new usage steps in the README

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6844cb3ade10832283d9c6d154c29460